### PR TITLE
Fix election voting viewing based on accepting_votes, closes #180

### DIFF
--- a/client/scripts/components/modules/vote/VotingBooth.jsx
+++ b/client/scripts/components/modules/vote/VotingBooth.jsx
@@ -25,22 +25,45 @@ var VotingBooth = React.createClass({
     var userId = 1;
     BallotActions.setUserAndElection(userId, electionId);
 
-    axios.get('/api/v1/elections/vote/' + electionId)
-          .then(function(response){
-            this.setState({polls: response.data});
-          }.bind(this))
-          .catch(function(response){
-            console.error(response);
-          });
+    axios.get('api/v1/elections/update/' + electionId)
+      .then(function(response){
+        // if currently accepting vote, then show polls
+        if(response.data.accepting_votes){
+          axios.get('/api/v1/elections/vote/' + electionId)
+            .then(function(election){
+              this.setState({polls: election.data});
+            }.bind(this))
+            .catch(function(election){
+              console.error(election);
+            });
+        } else {
+          // Get election start and end day to show?
+          this.setState({polls: "not_ready"});
+        }
+      }.bind(this))
+      .catch(function(response){
+        console.error(response);
+      });
+
   },
 
   render: function() {
-    if (this.state.polls === null) return (<Spinner/>);
+    // Check the state to decide show the right messages
+    if (this.state.polls === null) {
+      // Beginner state
+      var display = (<Spinner/>);
+    } else if (this.state.polls ==="not_ready"){
+      var display = (<div>This election is not currently accepting votes.</div>);
+    } else {
+      var display = (
+        <div>
+          <Election polls={this.state.polls}/>
+        </div>
+      )
+    }
 
     return (
-      <div>
-        <Election polls={this.state.polls}/>
-      </div>
+      <div>{display}</div>
     );
   },
 


### PR DESCRIPTION
The vote page will show not ready for accepting_votes = false election
![screen shot 2015-04-24 at 8 16 47 pm](https://cloud.githubusercontent.com/assets/8574617/7331370/2a13d2c6-eac1-11e4-8a7c-8033931d9a70.png)

If I updated accepting_votes to true, the poll can show up
![screen shot 2015-04-24 at 8 25 30 pm](https://cloud.githubusercontent.com/assets/8574617/7331375/4252d120-eac1-11e4-81eb-0759c135600d.png)
