### PR TITLE
Only polls for a user's associated group are now delivered during voting.

### DIFF
--- a/client/scripts/components/modules/admin/ListElection.jsx
+++ b/client/scripts/components/modules/admin/ListElection.jsx
@@ -39,7 +39,11 @@ var ListElection = React.createClass({
 			request.get('/api/v1/elections/update/' + this.props.id)
 			.query({open: true})
 			.end(function(err, response){
-				this.setState({accepting_votes: response.body.accepting_votes});
+				if (response.text && response.text === 'This election has been locked.'){
+					alert('This election has been locked and can no longer accept votes.');
+				} else{
+					this.setState({accepting_votes: response.body.accepting_votes});
+				}
 			}.bind(this));
 		} else {
 			if(confirm('Are you sure you wish to close this election? Results will be tabulated and no further votes accepted.')){

--- a/server/database/collections/polls.js
+++ b/server/database/collections/polls.js
@@ -1,8 +1,10 @@
-var db = require('../config');
-var Poll = require('../models/poll');
+'use strict';
 
-var Polls = new db.Collection();
+var db = require('../../config/database');
 
-Polls.model = Poll;
+var Polls = db.Collection.extend({
+  model: db.model('Poll')
+});
+
 
 module.exports = Polls;


### PR DESCRIPTION
:bug: Previously all polls for an election were delivered; now a user only receives the polls that have been created for its associated groups.